### PR TITLE
fix: use path.sep in path boundary checks

### DIFF
--- a/src/app/api/files/content/route.ts
+++ b/src/app/api/files/content/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
   // Boundary check: only serve files under home directory
   const resolved = path.resolve(filePath);
   const home = os.homedir();
-  if (!resolved.startsWith(home + "/") && resolved !== home) {
+  if (!resolved.startsWith(home + path.sep) && resolved !== home) {
     return NextResponse.json({ error: "Access denied: path outside home directory" }, { status: 403 });
   }
 

--- a/src/app/api/open-file/route.ts
+++ b/src/app/api/open-file/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
   // Normalize to resolve ".." traversal and check boundary
   resolved = path.resolve(resolved);
   const home = os.homedir();
-  if (!resolved.startsWith(home + "/") && resolved !== home) {
+  if (!resolved.startsWith(home + path.sep) && resolved !== home) {
     return Response.json({ error: "Access denied: path outside home directory" }, { status: 403 });
   }
 


### PR DESCRIPTION
## Summary
- Use `path.sep` instead of hardcoded `/` in security boundary checks
- Fixes file browser returning 403 on Windows

## Files changed
- `src/app/api/files/content/route.ts`
- `src/app/api/open-file/route.ts`

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)