### PR TITLE
fix: use npx.cmd on Windows to prevent ENOENT

### DIFF
--- a/src/app/api/sessions/[sessionId]/share/route.ts
+++ b/src/app/api/sessions/[sessionId]/share/route.ts
@@ -47,7 +47,8 @@ export async function POST(_req: NextRequest, { params }: Params) {
       args.push("--password", existing.password);
     }
 
-    const { stdout } = await execFileAsync("npx", args, {
+    const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
+    const { stdout } = await execFileAsync(npxBin, args, {
       timeout: 30_000,
       env: { ...process.env, PATH: process.env.PATH },
     });

--- a/src/lib/teamhub.ts
+++ b/src/lib/teamhub.ts
@@ -5,6 +5,7 @@ import path from "path";
 import os from "os";
 
 const execFileAsync = promisify(execFile);
+const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
 
 const CONFIG_PATH = path.join(os.homedir(), ".teamhub", "config.yaml");
 
@@ -77,7 +78,7 @@ export async function getTeamHubContext(
   try {
     // Try dynamic search first (most relevant for the query)
     const { stdout: searchOut } = await execFileAsync(
-      "npx",
+      npxBin,
       ["teamhub", "search", query, "-p", projectPath, "--top", "5", "--raw"],
       { timeout: 10_000, cwd: projectPath }
     );
@@ -92,7 +93,7 @@ export async function getTeamHubContext(
 
   try {
     const { stdout: injectOut } = await execFileAsync(
-      "npx",
+      npxBin,
       ["teamhub", "inject", "-p", projectPath, "--max-tokens", String(maxTokens)],
       { timeout: 10_000, cwd: projectPath }
     );


### PR DESCRIPTION
## Summary
- Use `npx.cmd` instead of `npx` on Windows
- Fixes TeamHub and session sharing

## Files changed
- `src/lib/teamhub.ts`
- `src/app/api/sessions/[sessionId]/share/route.ts`

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)