### PR TITLE
feat: add Windows and Linux support for open-file API

### DIFF
--- a/src/app/api/open-file/route.ts
+++ b/src/app/api/open-file/route.ts
@@ -31,7 +31,8 @@ export async function POST(request: NextRequest) {
     let proc;
     if (process.platform === "win32") {
       // Windows: use explorer to reveal file
-      proc = spawn("explorer", action === "reveal" ? ["/select,", resolved] : [resolved]);
+      // explorer expects "/select,path" as a single argument
+      proc = spawn("explorer", action === "reveal" ? [`/select,${resolved}`] : [resolved], { windowsHide: true });
     } else if (process.platform === "darwin") {
       // macOS: use open command
       const args = action === "reveal" ? ["-R", resolved] : [resolved];


### PR DESCRIPTION
## Summary
- Windows: `explorer /select,` to reveal files
- Linux: `xdg-open` on directory
- Fix path boundary check (`path.sep`)
- Support Windows drive letter paths

## Files changed
- `src/app/api/open-file/route.ts`

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)