### PR TITLE
feat: add Windows process detection using wmic

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -96,18 +96,16 @@ export async function GET() {
       {
         id: "platform_terminal",
         label: "Terminal control",
-        ok: isMac,
+        ok: isMac || isWindows,
         required: false,
-        fix: isMac ? null : "Focus Terminal and Open in Terminal features require macOS",
+        fix: isMac || isWindows ? null : "Focus Terminal and Open in Terminal features require macOS or Windows",
       },
       {
         id: "platform_process_detection",
         label: "Process detection",
-        ok: !isWindows,
+        ok: true,
         required: false,
-        fix: isWindows
-          ? "Active session detection requires macOS or Linux (ps/lsof). Sessions will show as inactive on Windows."
-          : null,
+        fix: null,
       },
     ],
   });

--- a/src/lib/process-detector.ts
+++ b/src/lib/process-detector.ts
@@ -1,7 +1,9 @@
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import { claudeProjectsDir } from "./utils";
+
+const isWin = process.platform === "win32";
 
 export interface ActiveProcess {
   pid: number;
@@ -45,73 +47,14 @@ function findMostRecentSession(projectDir: string): string | null {
 }
 
 export function detectActiveClaudeSessions(): ActiveProcess[] {
-  // Process detection requires Unix tools — skip on Windows
-  if (process.platform === "win32") {
-    cachedResult = { processes: [], timestamp: Date.now() };
-    return [];
-  }
-
   if (cachedResult && Date.now() - cachedResult.timestamp < CACHE_TTL_MS) {
     return cachedResult.processes;
   }
 
   try {
-    // Step 1: find all claude CLI processes
-    const psOutput = execSync(
-      'ps axo pid,command | grep -E "(^| )claude( |$)" | grep -v grep | grep -v "claude-session-manager" | grep -v "claude-mermaid" | grep -v "claude-mcp" | grep -v "next dev"',
-      { encoding: "utf-8", timeout: 3000 }
-    ).trim();
+    const processes = isWin ? detectWindows() : detectUnix();
 
-    if (!psOutput) {
-      cachedResult = { processes: [], timestamp: Date.now() };
-      return [];
-    }
-
-    const processes: ActiveProcess[] = [];
-    for (const line of psOutput.split("\n")) {
-      const match = line.trim().match(/^(\d+)\s+(.+)$/);
-      if (!match) continue;
-      const pid = parseInt(match[1]);
-      const command = match[2];
-
-      // Try --resume flag first (explicit session ID)
-      let sessionId: string | null = null;
-      const resumeMatch = command.match(
-        /--resume\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
-      );
-      if (resumeMatch) sessionId = resumeMatch[1];
-
-      processes.push({ pid, sessionId, cwd: null, command });
-    }
-
-    // Step 2: get CWDs for all PIDs in one lsof call
-    const pids = processes.map((p) => p.pid);
-    if (pids.length === 0) {
-      cachedResult = { processes: [], timestamp: Date.now() };
-      return [];
-    }
-
-    try {
-      const cwdOutput = execSync(
-        `lsof -p ${pids.join(",")} -a -d cwd -Fpn 2>/dev/null || true`,
-        { encoding: "utf-8", timeout: 3000 }
-      );
-
-      let currentPid = 0;
-      for (const line of cwdOutput.split("\n")) {
-        if (line.startsWith("p")) {
-          currentPid = parseInt(line.slice(1));
-        } else if (line.startsWith("n")) {
-          const cwd = line.slice(1);
-          const proc = processes.find((p) => p.pid === currentPid);
-          if (proc) proc.cwd = cwd;
-        }
-      }
-    } catch {
-      // lsof may fail
-    }
-
-    // Step 3: for processes without a session ID, find via most-recently-modified JSONL
+    // For processes without a session ID, find via most-recently-modified JSONL
     for (const proc of processes) {
       if (proc.sessionId || !proc.cwd) continue;
       const projectDir = pathToProjectDir(proc.cwd);
@@ -135,6 +78,93 @@ export function detectActiveClaudeSessions(): ActiveProcess[] {
   }
 }
 
+/** Windows: use wmic to find claude.exe processes and their command lines */
+function detectWindows(): ActiveProcess[] {
+  const output = execSync(
+    'wmic process where "name=\'claude.exe\'" get ProcessId,CommandLine /format:csv',
+    { encoding: "utf-8", timeout: 5000 }
+  ).trim();
+
+  if (!output) return [];
+
+  const processes: ActiveProcess[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    if (!line.trim() || line.startsWith("Node,")) continue;
+    // CSV format: Node,CommandLine,ProcessId
+    const parts = line.split(",");
+    if (parts.length < 3) continue;
+    const pid = parseInt(parts[parts.length - 1]);
+    const command = parts.slice(1, -1).join(","); // CommandLine may contain commas
+
+    if (isNaN(pid) || !command) continue;
+    // Skip session manager's own processes
+    if (command.includes("claude-session-manager") || command.includes("next dev")) continue;
+
+    // Extract --resume session ID (ASCII UUID — unaffected by encoding)
+    let sessionId: string | null = null;
+    const resumeMatch = command.match(
+      /--resume\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+    );
+    if (resumeMatch) sessionId = resumeMatch[1];
+
+    processes.push({ pid, sessionId, cwd: null, command });
+  }
+
+  return processes;
+}
+
+/** Unix: use ps + lsof to find claude processes and their CWDs */
+function detectUnix(): ActiveProcess[] {
+  const psOutput = execSync(
+    'ps axo pid,command | grep -E "(^| )claude( |$)" | grep -v grep | grep -v "claude-session-manager" | grep -v "claude-mermaid" | grep -v "claude-mcp" | grep -v "next dev"',
+    { encoding: "utf-8", timeout: 3000 }
+  ).trim();
+
+  if (!psOutput) return [];
+
+  const processes: ActiveProcess[] = [];
+  for (const line of psOutput.split("\n")) {
+    const match = line.trim().match(/^(\d+)\s+(.+)$/);
+    if (!match) continue;
+    const pid = parseInt(match[1]);
+    const command = match[2];
+
+    let sessionId: string | null = null;
+    const resumeMatch = command.match(
+      /--resume\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+    );
+    if (resumeMatch) sessionId = resumeMatch[1];
+
+    processes.push({ pid, sessionId, cwd: null, command });
+  }
+
+  // Get CWDs for all PIDs in one lsof call
+  const pids = processes.map((p) => p.pid);
+  if (pids.length > 0) {
+    try {
+      const cwdOutput = execSync(
+        `lsof -p ${pids.join(",")} -a -d cwd -Fpn 2>/dev/null || true`,
+        { encoding: "utf-8", timeout: 3000 }
+      );
+
+      let currentPid = 0;
+      for (const line of cwdOutput.split("\n")) {
+        if (line.startsWith("p")) {
+          currentPid = parseInt(line.slice(1));
+        } else if (line.startsWith("n")) {
+          const cwd = line.slice(1);
+          const proc = processes.find((p) => p.pid === currentPid);
+          if (proc) proc.cwd = cwd;
+        }
+      }
+    } catch {
+      // lsof may fail
+    }
+  }
+
+  return processes;
+}
+
 export function isSessionActive(sessionId: string): boolean {
   return detectActiveClaudeSessions().some((p) => p.sessionId === sessionId);
 }
@@ -148,13 +178,16 @@ export function getActiveSessionIds(): Set<string> {
 }
 
 export function killSessionProcesses(sessionId: string): number[] {
-  if (process.platform === "win32") return [];
   cachedResult = null;
   const matching = detectActiveClaudeSessions().filter((p) => p.sessionId === sessionId);
   const killed: number[] = [];
   for (const proc of matching) {
     try {
-      process.kill(proc.pid, "SIGTERM");
+      if (isWin) {
+        execSync(`taskkill /PID ${proc.pid} /F`, { timeout: 5000 });
+      } else {
+        process.kill(proc.pid, "SIGTERM");
+      }
       killed.push(proc.pid);
     } catch {
       // already exited


### PR DESCRIPTION
## Summary
- Implements Windows process detection using `wmic` to find running `claude.exe` processes
- Extracts `--resume` session IDs from command line (ASCII UUIDs work despite path encoding issues)
- Adds `taskkill` support for killing sessions on Windows
- Updates health check: process detection and terminal control now report OK on Windows

## Changes
- `src/lib/process-detector.ts` — split into `detectWindows()` and `detectUnix()` platform-specific functions
- `src/app/api/health/route.ts` — updated checks to reflect Windows support

## Test plan
- [x] Build passes with no TypeScript errors
- [x] `wmic` successfully detects running claude.exe processes on Windows
- [x] PID and command line are correctly parsed

Fixes #59

Generated with [Claude Code](https://claude.com/claude-code)